### PR TITLE
schema test updates

### DIFF
--- a/models/stitch/schema.yml
+++ b/models/stitch/schema.yml
@@ -1,19 +1,31 @@
-taboola_campaign_performance:
-    constraints:
-        not_null:
-            - id
-            - date_day
-            - campaign_id
-            - spend
-        unique:
-            - id
-        relationships:
-            - {from: campaign_id, to: taboola_campaigns, field: id}
+version: 2
 
-taboola_campaigns:
-    constraints:
-        not_null:
-            - id
-            - start_date
-        unique:
-            - id
+models:
+    
+- name: taboola_campaign_performance
+  description: Base model for taboola campaign performance
+  columns:
+  - name: id
+    tests:
+    - not_null
+    - unique
+  - name: date_day
+    tests:
+    - not_null
+  - name: campaign_id
+    tests:
+    - not_null
+  - name: spend
+    tests:
+    - not_null
+
+- name: taboola_campaigns
+  description: Base model for taboola campaigns 
+  columns:
+  - name: id
+    tests:
+    - not_null
+    - unique
+  - name: start_date
+    tests:
+    - not_null

--- a/models/stitch/transform/taboola_campaign_performance_xf.sql
+++ b/models/stitch/transform/taboola_campaign_performance_xf.sql
@@ -22,7 +22,7 @@ joined as (
         campaigns.utm_term
 
     from performance
-    inner join campaigns on performance.campaign_id = campaigns.id
+    left join campaigns on performance.campaign_id = campaigns.id
 
 )
 


### PR DESCRIPTION
* upgrade to schema v2
* remove a test that was failing for me. for one of my accounts, campaigns (perhaps old ones that fall before the historical sync date of the integration?) that exist in campaign_performance don't always exist in the campaigns table
* for the above reason, I changed inner join to a left join in campaign_performance_xf

